### PR TITLE
Add EDL parameter parsing and plane coefficients

### DIFF
--- a/Source/concentration.F90
+++ b/Source/concentration.F90
@@ -169,6 +169,12 @@ MODULE  concentration
   REAL(DP), DIMENSION(:), ALLOCATABLE              :: alogkp
   REAL(DP), DIMENSION(:), ALLOCATABLE              :: wtaq
   REAL(DP), DIMENSION(:), ALLOCATABLE              :: zsurf
+  REAL(DP), DIMENSION(:), ALLOCATABLE              :: z0_s
+  REAL(DP), DIMENSION(:), ALLOCATABLE              :: zb_s
+  REAL(DP), DIMENSION(:), ALLOCATABLE              :: zd_s
+  REAL(DP), DIMENSION(:), ALLOCATABLE              :: C1
+  REAL(DP), DIMENSION(:), ALLOCATABLE              :: C2
+  REAL(DP), DIMENSION(:), ALLOCATABLE              :: eps_r
   REAL(DP), DIMENSION(:), ALLOCATABLE              :: satkin
   REAL(DP), DIMENSION(:,:), ALLOCATABLE            :: spexb
   REAL(DP), DIMENSION(:,:), ALLOCATABLE            :: spsurfb


### PR DESCRIPTION
## Summary
- add storage for EDL capacitance and plane coefficients
- parse optional `Begin edl parameters` block
- support `planes = a b c` tokens in surface complexation parameters with validation

## Testing
- `make` *(fails: No rule to make target '/lib/petsc/conf/rules')*

------
https://chatgpt.com/codex/tasks/task_e_68ad10b7cf1483278317673ac75d104c