### PR TITLE
Expand potential unknowns and add plane-major index

### DIFF
--- a/Source/AllocateGIMRT.F90
+++ b/Source/AllocateGIMRT.F90
@@ -276,11 +276,11 @@ IF (ierode == 1) THEN
   IF (ALLOCATED(fjpotncomp)) THEN
     DEALLOCATE(fjpotncomp)
   END IF
-  ALLOCATE(fjpotncomp(npot,ncomp,nx,ny,nz))
+  ALLOCATE(fjpotncomp(3*npot,ncomp,nx,ny,nz))
   IF (ALLOCATED(fjpotnsurf)) THEN
     DEALLOCATE(fjpotnsurf)
   END IF
-  ALLOCATE(fjpotnsurf(npot,nsurf,nx,ny,nz))
+  ALLOCATE(fjpotnsurf(3*npot,nsurf,nx,ny,nz))
 
 
 
@@ -321,11 +321,11 @@ ELSE IF (ierode /= 1) THEN
   IF (ALLOCATED(fjpotncomp)) THEN
     DEALLOCATE(fjpotncomp)
   END IF
-  ALLOCATE(fjpotncomp(npot,ncomp,nx,ny,nz))
+  ALLOCATE(fjpotncomp(3*npot,ncomp,nx,ny,nz))
   IF (ALLOCATED(fjpotnsurf)) THEN
     DEALLOCATE(fjpotnsurf)
   END IF
-  ALLOCATE(fjpotnsurf(npot,nsurf,nx,ny,nz))
+  ALLOCATE(fjpotnsurf(3*npot,nsurf,nx,ny,nz))
   IF (ALLOCATED(LogPotential)) THEN
     DEALLOCATE(LogPotential)
   END IF

--- a/Source/AllocateOS3D.F90
+++ b/Source/AllocateOS3D.F90
@@ -1,17 +1,17 @@
 !!! *** Copyright Notice ***
-!!! ìCrunchFlowî, Copyright (c) 2016, The Regents of the University of California, through Lawrence Berkeley National Laboratory 
-!!! (subject to receipt of any required approvals from the U.S. Dept. of Energy).† All rights reserved.
-!!!†
+!!! ‚ÄúCrunchFlow‚Äù, Copyright (c) 2016, The Regents of the University of California, through Lawrence Berkeley National Laboratory 
+!!! (subject to receipt of any required approvals from the U.S. Dept. of Energy).¬† All rights reserved.
+!!!¬†
 !!! If you have questions about your rights to use or distribute this software, please contact 
-!!! Berkeley Lab's Innovation & Partnerships Office at††IPO@lbl.gov.
-!!!†
-!!! NOTICE.† This Software was developed under funding from the U.S. Department of Energy and the U.S. Government 
+!!! Berkeley Lab's Innovation & Partnerships Office at¬†¬†IPO@lbl.gov.
+!!!¬†
+!!! NOTICE.¬† This Software was developed under funding from the U.S. Department of Energy and the U.S. Government 
 !!! consequently retains certain rights. As such, the U.S. Government has been granted for itself and others acting 
 !!! on its behalf a paid-up, nonexclusive, irrevocable, worldwide license in the Software to reproduce, distribute copies to the public, 
 !!! prepare derivative works, and perform publicly and display publicly, and to permit other to do so.
 !!!
 !!! *** License Agreement ***
-!!! ìCrunchFlowî, Copyright (c) 2016, The Regents of the University of California, through Lawrence Berkeley National Laboratory)
+!!! ‚ÄúCrunchFlow‚Äù, Copyright (c) 2016, The Regents of the University of California, through Lawrence Berkeley National Laboratory)
 !!! subject to receipt of any required approvals from the U.S. Dept. of Energy).  All rights reserved."
 !!! 
 !!! Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
@@ -265,11 +265,11 @@ f = 0.0
   IF (ALLOCATED(fjpotncomp_local)) THEN
     DEALLOCATE(fjpotncomp_local)
   END IF
-  ALLOCATE(fjpotncomp_local(npot,ncomp))
+  ALLOCATE(fjpotncomp_local(3*npot,ncomp))
   IF (ALLOCATED(fjpotnsurf_local)) THEN
     DEALLOCATE(fjpotnsurf_local)
   END IF
-  ALLOCATE(fjpotnsurf_local(npot,nsurf))
+  ALLOCATE(fjpotnsurf_local(3*npot,nsurf))
   fjpotncomp_local = 0.0
   fjpotnsurf_local = 0.0
   IF (spherical) THEN

--- a/Source/CrunchFunctions.F90
+++ b/Source/CrunchFunctions.F90
@@ -1,17 +1,17 @@
 !!! *** Copyright Notice ***
-!!! ìCrunchFlowî, Copyright (c) 2016, The Regents of the University of California, through Lawrence Berkeley National Laboratory 
-!!! (subject to receipt of any required approvals from the U.S. Dept. of Energy).† All rights reserved.
-!!!†
+!!! ‚ÄúCrunchFlow‚Äù, Copyright (c) 2016, The Regents of the University of California, through Lawrence Berkeley National Laboratory 
+!!! (subject to receipt of any required approvals from the U.S. Dept. of Energy).¬† All rights reserved.
+!!!¬†
 !!! If you have questions about your rights to use or distribute this software, please contact 
-!!! Berkeley Lab's Innovation & Partnerships Office at††IPO@lbl.gov.
-!!!†
-!!! NOTICE.† This Software was developed under funding from the U.S. Department of Energy and the U.S. Government 
+!!! Berkeley Lab's Innovation & Partnerships Office at¬†¬†IPO@lbl.gov.
+!!!¬†
+!!! NOTICE.¬† This Software was developed under funding from the U.S. Department of Energy and the U.S. Government 
 !!! consequently retains certain rights. As such, the U.S. Government has been granted for itself and others acting 
 !!! on its behalf a paid-up, nonexclusive, irrevocable, worldwide license in the Software to reproduce, distribute copies to the public, 
 !!! prepare derivative works, and perform publicly and display publicly, and to permit other to do so.
 !!!
 !!! *** License Agreement ***
-!!! ìCrunchFlowî, Copyright (c) 2016, The Regents of the University of California, through Lawrence Berkeley National Laboratory)
+!!! ‚ÄúCrunchFlow‚Äù, Copyright (c) 2016, The Regents of the University of California, through Lawrence Berkeley National Laboratory)
 !!! subject to receipt of any required approvals from the U.S. Dept. of Energy).  All rights reserved."
 !!! 
 !!! Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
@@ -175,5 +175,20 @@ REAL(DP), DIMENSION(size(a),size(b))                       :: outerprod
 
 outerprod = spread(a,dim=2,ncopies=size(b)) * spread(b,dim=1,ncopies=size(a))
 END FUNCTION outerprod
+
+PURE FUNCTION PlaneMajorOffset(iplane,p,npot,ncells)
+USE crunchtype
+INTEGER(I4B), INTENT(IN) :: iplane,p,npot,ncells
+INTEGER(I4B)             :: PlaneMajorOffset
+PlaneMajorOffset = ((iplane-1)*npot + (p-1))*ncells
+END FUNCTION PlaneMajorOffset
+
+PURE FUNCTION PlaneMajorIndex(iplane,p,cell,npot,ncells)
+USE crunchtype
+INTEGER(I4B), INTENT(IN) :: iplane,p,cell,npot,ncells
+INTEGER(I4B)             :: PlaneMajorIndex
+PlaneMajorIndex = PlaneMajorOffset(iplane,p,npot,ncells) + cell
+END FUNCTION PlaneMajorIndex
+
 
 END MODULE CrunchFunctions

--- a/Source/StartTope.F90
+++ b/Source/StartTope.F90
@@ -2543,8 +2543,9 @@ END DO
 !!!    ksurf(islink(ns)) --> This would point from a secondary surface complex (ns) to a primary (islink(ns)) complex to a mineral
 !!!    nptlink(ns) --> pointer of surface complex (secondary) to potential (npt)
 
-!!!neqn = ncomp + nsurf + nexchange + npot + 1 + 1   [For now, "equilib.F90' will not consider the two new unknowns]
-neqn = ncomp + nsurf + nexchange + npot
+!!!neqn = ncomp + nsurf + nexchange + npot + 1 + 1   [For now, "equilib.F90" will not consider the two new unknowns]
+!!!Three unknowns are inserted for each potential set
+neqn = ncomp + nsurf + nexchange + 3*npot
 
 !  Temporary arrays deallocated later in START98
 


### PR DESCRIPTION
## Summary
- Allocate three unknowns per potential set and size derivative work arrays accordingly
- Add plane-major index helpers for consistent `(iplane,p,cell)` flattening

## Testing
- `make CrunchMain` *(fails: No rule to make target '/lib/petsc/conf/rules')*


------
https://chatgpt.com/codex/tasks/task_e_68ad1547f4bc8327bec27cd75e8a4a30