### PR TITLE
Add TLM demo and parser/model tests

### DIFF
--- a/examples/tlm_demo.in
+++ b/examples/tlm_demo.in
@@ -1,0 +1,18 @@
+# Demonstration of the ``edl parameters`` block and ``planes=`` syntax
+# for triple layer model surface-complexation.
+
+SURFACE_COMPLEXATION
+    # Each surface site can optionally specify plane fractions that
+    # sum to unity using the ``planes=`` keyword.
+    >FeOH      5.0   planes= 0.5 0.3 0.2
+    >FeOH2     2.0   planes= 0.3 0.4 0.3
+End
+
+# The electrical double layer properties for each site are defined
+# within an ``edl parameters`` block.  Each entry lists the site name
+# followed by C1, C2 and the relative dielectric constant.
+Begin edl parameters
+  >FeOH   1.0  0.2  78.5
+  >FeOH2  1.5  0.3  80.0
+End edl parameters
+

--- a/psi_crunch/__init__.py
+++ b/psi_crunch/__init__.py
@@ -1,0 +1,15 @@
+"""Utility functions for simplified CrunchFlow examples."""
+from .parser import parse_edl_block, parse_planes_line
+from .models import (
+    gouy_chapman_potential,
+    constant_capacitance,
+    triple_layer,
+)
+
+__all__ = [
+    'parse_edl_block',
+    'parse_planes_line',
+    'gouy_chapman_potential',
+    'constant_capacitance',
+    'triple_layer',
+]

--- a/psi_crunch/models.py
+++ b/psi_crunch/models.py
@@ -1,0 +1,32 @@
+"""Simple electrostatic models used for testing."""
+from __future__ import annotations
+
+import math
+from typing import Iterable, List
+
+
+def gouy_chapman_potential(ionic_strength: float, surface_charge: float) -> float:
+    """Return a toy Gouy--Chapman potential in volts.
+
+    The implementation is intentionally lightweight; it simply returns
+    ``surface_charge / sqrt(ionic_strength)`` which captures the
+    qualitative trend of decreasing potential with increasing ionic
+    strength.
+    """
+    if ionic_strength <= 0:
+        raise ValueError("ionic strength must be positive")
+    return surface_charge / math.sqrt(ionic_strength)
+
+
+def constant_capacitance(ionic_strength: float, surface_charge: float, capacitance: float) -> float:
+    """Constant Capacitance Model (CCM) potential."""
+    return surface_charge / capacitance
+
+
+def triple_layer(ionic_strength: float, surface_charge: float, C1: float, C2: float) -> float:
+    """Triple Layer Model (TLM) potential.
+
+    A toy implementation where the effective capacitance increases with
+    ionic strength through the Stern layer capacitor ``C2``.
+    """
+    return surface_charge / (C1 + C2 * ionic_strength)

--- a/psi_crunch/parser.py
+++ b/psi_crunch/parser.py
@@ -1,0 +1,76 @@
+"""Parsers for EDL parameters and plane coefficients.
+
+These lightweight helpers mimic the behaviour of the Fortran
+parsers used in CrunchFlow's surface-complexation routines. They are
+not intended to be a full replacement but provide enough
+functionality for unit testing.
+"""
+from __future__ import annotations
+
+from typing import Dict, Iterable, Tuple
+
+
+def parse_planes_line(line: str) -> Dict[str, Tuple[float, float, float]]:
+    """Parse a line containing the optional ``planes=`` syntax.
+
+    Parameters
+    ----------
+    line:
+        Input line describing a surface site.  An example is::
+
+            ">FeOH 5.0 planes= 0.5 0.3 0.2"
+
+    Returns
+    -------
+    dict
+        Mapping with keys ``site``, ``z`` (the zeta potential) and
+        ``planes`` containing a tuple of the three plane coefficients.
+    """
+    tokens = line.strip().split()
+    if len(tokens) < 2:
+        raise ValueError("line missing site or z value")
+    site = tokens[0]
+    z = float(tokens[1])
+    planes = (None, None, None)
+    if 'planes=' in tokens:
+        idx = tokens.index('planes=') + 1
+        try:
+            planes = tuple(float(tokens[idx + i]) for i in range(3))
+        except (IndexError, ValueError) as exc:  # pragma: no cover - defensive
+            raise ValueError("invalid planes specification") from exc
+    return {'site': site, 'z': z, 'planes': planes}
+
+
+def parse_edl_block(lines: Iterable[str]) -> Dict[str, Tuple[float, float, float]]:
+    """Parse an ``edl parameters`` block.
+
+    Parameters
+    ----------
+    lines:
+        Iterable over lines of an input file.  Only the portion between
+        ``Begin edl parameters`` and ``End edl parameters`` is read.
+
+    Returns
+    -------
+    dict
+        Mapping from surface site names to ``(C1, C2, eps_r)`` tuples.
+    """
+    capture = False
+    params: Dict[str, Tuple[float, float, float]] = {}
+    for raw in lines:
+        line = raw.strip()
+        if not line:
+            continue
+        lower = line.lower()
+        if lower.startswith('begin edl parameters'):
+            capture = True
+            continue
+        if lower.startswith('end edl parameters'):
+            break
+        if capture:
+            parts = line.split()
+            if len(parts) >= 4:
+                site = parts[0]
+                values = tuple(float(p) for p in parts[1:4])
+                params[site] = values
+    return params

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import os
+import sys
+
+# Ensure the project root is on the import path for the tests
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)

--- a/tests/test_gouy_chapman.py
+++ b/tests/test_gouy_chapman.py
@@ -1,0 +1,18 @@
+import math
+from psi_crunch import gouy_chapman_potential
+
+
+def test_gouy_chapman_potential_basic():
+    psi = gouy_chapman_potential(0.01, surface_charge=1.0)
+    assert math.isclose(psi, 10.0)
+
+
+def test_gouy_chapman_requires_positive_ionic_strength():
+    try:
+        gouy_chapman_potential(0.0, 1.0)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("expected ValueError for zero ionic strength")
+
+

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,20 @@
+from psi_crunch import constant_capacitance, triple_layer
+
+
+def test_ccm_vs_tlm_ionic_strength_sweep():
+    strengths = [1e-3, 1e-2, 1e-1]
+    surface_charge = 1.0
+    ccm_results = [
+        constant_capacitance(i, surface_charge, capacitance=1.0)
+        for i in strengths
+    ]
+    tlm_results = [
+        triple_layer(i, surface_charge, C1=1.0, C2=2.0)
+        for i in strengths
+    ]
+    # CCM is independent of ionic strength
+    assert ccm_results == [ccm_results[0]] * len(strengths)
+    # TLM potential decreases with ionic strength and is lower than CCM
+    assert tlm_results[0] > tlm_results[-1]
+    assert all(t < c for t, c in zip(tlm_results, ccm_results))
+

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,24 @@
+from psi_crunch import parse_edl_block, parse_planes_line
+
+
+def test_parse_planes_line():
+    line = ">FeOH 5.0 planes= 0.5 0.3 0.2"
+    result = parse_planes_line(line)
+    assert result["site"] == ">FeOH"
+    assert result["z"] == 5.0
+    assert result["planes"] == (0.5, 0.3, 0.2)
+
+
+def test_parse_edl_block():
+    lines = [
+        "irrelevant line",
+        "Begin edl parameters",
+        "  >FeOH   1.0  0.2  78.5",
+        "  >FeOH2  1.5  0.3  80.0",
+        "End edl parameters",
+    ]
+    params = parse_edl_block(lines)
+    assert params[">FeOH"] == (1.0, 0.2, 78.5)
+    assert params[">FeOH2"] == (1.5, 0.3, 80.0)
+    assert len(params) == 2
+


### PR DESCRIPTION
## Summary
- Add `examples/tlm_demo.in` demonstrating new `edl parameters` block and `planes=` syntax
- Provide lightweight parsers and electrostatic models for testing
- Create unit tests for parser and Gouy–Chapman functions with CCM vs. TLM integration sweep

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad1e3d34748327a63f15ec932a3b22