### PR TITLE
Handle case-insensitive planes keyword and attached values

### DIFF
--- a/psi_crunch/parser.py
+++ b/psi_crunch/parser.py
@@ -32,12 +32,26 @@ def parse_planes_line(line: str) -> Dict[str, Tuple[float, float, float]]:
     site = tokens[0]
     z = float(tokens[1])
     planes = (None, None, None)
-    if 'planes=' in tokens:
-        idx = tokens.index('planes=') + 1
-        try:
-            planes = tuple(float(tokens[idx + i]) for i in range(3))
-        except (IndexError, ValueError) as exc:  # pragma: no cover - defensive
-            raise ValueError("invalid planes specification") from exc
+
+    tokens_lower = [t.lower() for t in tokens]
+    for idx, tok in enumerate(tokens_lower):
+        if tok == 'planes=':
+            start = idx + 1
+            try:
+                planes = tuple(float(tokens[start + i]) for i in range(3))
+            except (IndexError, ValueError) as exc:  # pragma: no cover - defensive
+                raise ValueError("invalid planes specification") from exc
+            break
+        elif tok.startswith('planes='):
+            first = tokens[idx][len('planes='):]
+            try:
+                planes = tuple(
+                    float(val) for val in [first] + tokens[idx + 1 : idx + 3]
+                )
+            except (IndexError, ValueError) as exc:  # pragma: no cover - defensive
+                raise ValueError("invalid planes specification") from exc
+            break
+
     return {'site': site, 'z': z, 'planes': planes}
 
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -9,6 +9,18 @@ def test_parse_planes_line():
     assert result["planes"] == (0.5, 0.3, 0.2)
 
 
+def test_parse_planes_line_uppercase():
+    line = ">FeOH 5.0 PLANES= 0.5 0.3 0.2"
+    result = parse_planes_line(line)
+    assert result["planes"] == (0.5, 0.3, 0.2)
+
+
+def test_parse_planes_line_attached_value():
+    line = ">FeOH 5.0 planes=0.5 0.3 0.2"
+    result = parse_planes_line(line)
+    assert result["planes"] == (0.5, 0.3, 0.2)
+
+
 def test_parse_edl_block():
     lines = [
         "irrelevant line",


### PR DESCRIPTION
## Summary
- Normalize plane parsing tokens to lower case before searching
- Support `planes=` values attached to the keyword
- Test uppercase and attached `planes` forms

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad2144d520832791346a673f9d329b