### PR TITLE
Make EDL parameter parsing case-insensitive

### DIFF
--- a/Source/find_string.F90
+++ b/Source/find_string.F90
@@ -1,17 +1,17 @@
 !!! *** Copyright Notice ***
-!!! ìCrunchFlowî, Copyright (c) 2016, The Regents of the University of California, through Lawrence Berkeley National Laboratory 
-!!! (subject to receipt of any required approvals from the U.S. Dept. of Energy).† All rights reserved.
-!!!†
+!!! ‚ÄúCrunchFlow‚Äù, Copyright (c) 2016, The Regents of the University of California, through Lawrence Berkeley National Laboratory 
+!!! (subject to receipt of any required approvals from the U.S. Dept. of Energy).¬† All rights reserved.
+!!!¬†
 !!! If you have questions about your rights to use or distribute this software, please contact 
-!!! Berkeley Lab's Innovation & Partnerships Office at††IPO@lbl.gov.
-!!!†
-!!! NOTICE.† This Software was developed under funding from the U.S. Department of Energy and the U.S. Government 
+!!! Berkeley Lab's Innovation & Partnerships Office at¬†¬†IPO@lbl.gov.
+!!!¬†
+!!! NOTICE.¬† This Software was developed under funding from the U.S. Department of Energy and the U.S. Government 
 !!! consequently retains certain rights. As such, the U.S. Government has been granted for itself and others acting 
 !!! on its behalf a paid-up, nonexclusive, irrevocable, worldwide license in the Software to reproduce, distribute copies to the public, 
 !!! prepare derivative works, and perform publicly and display publicly, and to permit other to do so.
 !!!
 !!! *** License Agreement ***
-!!! ìCrunchFlowî, Copyright (c) 2016, The Regents of the University of California, through Lawrence Berkeley National Laboratory)
+!!! ‚ÄúCrunchFlow‚Äù, Copyright (c) 2016, The Regents of the University of California, through Lawrence Berkeley National Laboratory)
 !!! subject to receipt of any required approvals from the U.S. Dept. of Energy).  All rights reserved."
 !!! 
 !!! Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
@@ -57,15 +57,23 @@ INTEGER(I4B), INTENT(OUT)                     :: ifind
 !  Internal variables
 
 CHARACTER (LEN=mls)                           :: dummy1
+CHARACTER (LEN=mls)                           :: dummy1_lower
+CHARACTER (LEN=mls)                           :: dumstring_lower
+
+
+dumstring_lower = dumstring
+CALL majuscules(dumstring_lower,LEN_TRIM(dumstring_lower))
 
 ifind = 0
 
 main:  DO
   READ(iunit,'(a)') dummy1
-  IF (dummy1 == dumstring) THEN
+  dummy1_lower = dummy1
+  CALL majuscules(dummy1_lower,LEN_TRIM(dummy1_lower))
+  IF (dummy1_lower == dumstring_lower) THEN
     ifind = 1
     EXIT main
-  ELSE IF (dummy1 == 'stop.') THEN
+  ELSE IF (dummy1_lower == 'stop.') THEN
     WRITE(*,*) 
     WRITE(*,*) ' String not found: ', dumstring
     WRITE(*,*)

--- a/Source/read_surface.F90
+++ b/Source/read_surface.F90
@@ -198,6 +198,7 @@ SUBROUTINE read_edl_parameters(iunit,nsurf,nsurf_sec)
   INTEGER(I4B), INTENT(IN) :: nsurf_sec
 
   CHARACTER (LEN=mls) :: line
+  CHARACTER (LEN=mls) :: line_lower
   CHARACTER (LEN=mls) :: name
   INTEGER(I4B) :: ifind
   INTEGER(I4B) :: id, iff, ids, ls
@@ -220,7 +221,9 @@ SUBROUTINE read_edl_parameters(iunit,nsurf,nsurf_sec)
 
   DO
     READ(iunit,'(a)',END=100) line
-    IF (line == 'End edl parameters') EXIT
+    line_lower = line
+    CALL majuscules(line_lower,LEN_TRIM(line_lower))
+    IF (line_lower == 'end edl parameters') EXIT
     id = 1
     iff = mls
     CALL sschaine(line,id,iff,ssch,ids,ls)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -63,6 +63,17 @@ def test_parse_edl_block_with_comments():
     assert len(params) == 2
 
 
+def test_parse_edl_block_case_insensitive_markers():
+    lines = [
+        "BEGIN EDL PARAMETERS",
+        "  >FeOH   1.0  0.2  78.5",
+        "EnD EdL PaRaMeTeRs",
+    ]
+    params = parse_edl_block(lines)
+    assert params[">FeOH"] == (1.0, 0.2, 78.5)
+    assert len(params) == 1
+
+
 def test_parse_edl_block_missing_end():
     lines = [
         "Begin edl parameters",


### PR DESCRIPTION
## Summary
- Normalize strings in `find_string` to enable case-insensitive search
- Convert lines to lower case when scanning for EDL block end marker
- Add regression test ensuring `parse_edl_block` accepts mixed-case markers

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68ad249f57dc83279ddccabdc8047b18