### PR TITLE
Warn on unmatched EDL sites

### DIFF
--- a/docs/input_file/surface_complexation.md
+++ b/docs/input_file/surface_complexation.md
@@ -17,3 +17,17 @@ followed by the keyword *--no_edl*, for example:
 
 The capability for surface complexation on the bulk material will be
 added soon.
+
+### EDL Parameters
+
+Electrostatic double-layer properties for surface sites are specified in an
+``edl parameters`` block::
+
+    Begin edl parameters
+      >FeOH   1.0  0.2  78.5
+    End edl parameters
+
+Each line defines the site name followed by ``C1``, ``C2`` and the dielectric
+constant ``eps_r``. Entries whose site names do not match any defined surface
+complex are ignored and a warning is issued so that unmatched sites can be
+identified and corrected.


### PR DESCRIPTION
## Summary
- track and warn about unmatched sites in `read_edl_parameters`
- expose unmatched sites from Python `parse_edl_block` with runtime warnings
- document how `edl parameters` flags unknown surface sites

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad26052bc0832781c94a028eb6104e