### PR TITLE
Validate capacitance values in models

### DIFF
--- a/psi_crunch/models.py
+++ b/psi_crunch/models.py
@@ -20,6 +20,8 @@ def gouy_chapman_potential(ionic_strength: float, surface_charge: float) -> floa
 
 def constant_capacitance(ionic_strength: float, surface_charge: float, capacitance: float) -> float:
     """Constant Capacitance Model (CCM) potential."""
+    if capacitance <= 0:
+        raise ValueError("capacitance must be positive")
     return surface_charge / capacitance
 
 
@@ -29,4 +31,8 @@ def triple_layer(ionic_strength: float, surface_charge: float, C1: float, C2: fl
     A toy implementation where the effective capacitance increases with
     ionic strength through the Stern layer capacitor ``C2``.
     """
+    if C1 <= 0:
+        raise ValueError("C1 must be positive")
+    if C2 <= 0:
+        raise ValueError("C2 must be positive")
     return surface_charge / (C1 + C2 * ionic_strength)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,3 +1,5 @@
+import pytest
+
 from psi_crunch import constant_capacitance, triple_layer
 
 
@@ -17,4 +19,19 @@ def test_ccm_vs_tlm_ionic_strength_sweep():
     # TLM potential decreases with ionic strength and is lower than CCM
     assert tlm_results[0] > tlm_results[-1]
     assert all(t < c for t, c in zip(tlm_results, ccm_results))
+
+
+def test_constant_capacitance_invalid_capacitance():
+    for bad_cap in [0.0, -1.0]:
+        with pytest.raises(ValueError, match="capacitance must be positive"):
+            constant_capacitance(1e-3, 1.0, capacitance=bad_cap)
+
+
+def test_triple_layer_invalid_coefficients():
+    for bad_c1 in [0.0, -1.0]:
+        with pytest.raises(ValueError, match="C1 must be positive"):
+            triple_layer(1e-3, 1.0, C1=bad_c1, C2=1.0)
+    for bad_c2 in [0.0, -1.0]:
+        with pytest.raises(ValueError, match="C2 must be positive"):
+            triple_layer(1e-3, 1.0, C1=1.0, C2=bad_c2)
 


### PR DESCRIPTION
## Summary
- ensure capacitance and layer coefficients are positive in electrostatic models
- add unit tests for invalid capacitance and coefficient values

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad26f8a6808327a32b6a1bd5eafd53