### PR TITLE
Avoid concentration module variable conflicts

### DIFF
--- a/Source/StartTope.F90
+++ b/Source/StartTope.F90
@@ -157,7 +157,7 @@ END INTERFACE
 
 
 INTERFACE
-SUBROUTINE read_multstring(nout,lchar,parchar,parfind, stringarray,lenarray,section)
+SUBROUTINE read_multstring(nout,lchar,parchar,parfind, strarray,lenarray,section)
 USE crunchtype
 USE params
 USE strings
@@ -166,7 +166,7 @@ INTEGER(I4B), INTENT(IN)                                    :: nout
 INTEGER(I4B), INTENT(OUT)                                   :: lchar
 CHARACTER (LEN=mls), INTENT(IN)                             :: parchar
 CHARACTER (LEN=mls), INTENT(IN OUT)                         :: parfind
-CHARACTER (LEN=mls), DIMENSION(:), INTENT(IN OUT)           :: stringarray
+CHARACTER (LEN=mls), DIMENSION(:), INTENT(IN OUT)           :: strarray
 INTEGER(I4B), INTENT(OUT)                                   :: lenarray
 CHARACTER (LEN=mls), INTENT(IN)                             :: section
 END SUBROUTINE read_multstring

--- a/Source/jacobian_numerical.F90
+++ b/Source/jacobian_numerical.F90
@@ -1,17 +1,17 @@
 !!! *** Copyright Notice ***
-!!! ìCrunchFlowî, Copyright (c) 2016, The Regents of the University of California, through Lawrence Berkeley National Laboratory 
-!!! (subject to receipt of any required approvals from the U.S. Dept. of Energy).† All rights reserved.
-!!!†
+!!! ‚ÄúCrunchFlow‚Äù, Copyright (c) 2016, The Regents of the University of California, through Lawrence Berkeley National Laboratory 
+!!! (subject to receipt of any required approvals from the U.S. Dept. of Energy).¬† All rights reserved.
+!!!¬†
 !!! If you have questions about your rights to use or distribute this software, please contact 
-!!! Berkeley Lab's Innovation & Partnerships Office at††IPO@lbl.gov.
-!!!†
-!!! NOTICE.† This Software was developed under funding from the U.S. Department of Energy and the U.S. Government 
+!!! Berkeley Lab's Innovation & Partnerships Office at¬†¬†IPO@lbl.gov.
+!!!¬†
+!!! NOTICE.¬† This Software was developed under funding from the U.S. Department of Energy and the U.S. Government 
 !!! consequently retains certain rights. As such, the U.S. Government has been granted for itself and others acting 
 !!! on its behalf a paid-up, nonexclusive, irrevocable, worldwide license in the Software to reproduce, distribute copies to the public, 
 !!! prepare derivative works, and perform publicly and display publicly, and to permit other to do so.
 !!!
 !!! *** License Agreement ***
-!!! ìCrunchFlowî, Copyright (c) 2016, The Regents of the University of California, through Lawrence Berkeley National Laboratory)
+!!! ‚ÄúCrunchFlow‚Äù, Copyright (c) 2016, The Regents of the University of California, through Lawrence Berkeley National Laboratory)
 !!! subject to receipt of any required approvals from the U.S. Dept. of Energy).  All rights reserved."
 !!! 
 !!! Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
@@ -79,17 +79,17 @@ REAL(DP)                                             :: perturb=1.0E-09
 REAL(DP)                                                    :: tempc
 REAL(DP), ALLOCATABLE, DIMENSION(:)                         :: spppTMP
 REAL(DP), ALLOCATABLE, DIMENSION(:)                         :: spppTMP10
-REAL(DP), ALLOCATABLE, DIMENSION(:)                         :: keqaqTMP
+REAL(DP), ALLOCATABLE, DIMENSION(:)                         :: keqaqTMP_local
 REAL(DP), ALLOCATABLE, DIMENSION(:)                         :: gammaTMP
 REAL(DP), ALLOCATABLE, DIMENSION(:)                         :: sTotTMP
-REAL(DP), ALLOCATABLE, DIMENSION(:,:)                       :: NumericalJac 
+REAL(DP), ALLOCATABLE, DIMENSION(:,:)                       :: NumericalJac_local 
 ;
 ALLOCATE(spppTMP(ncomp+nspec))
 ALLOCATE(spppTMP10(ncomp+nspec))
-ALLOCATE(keqaqTMP(nspec))
+ALLOCATE(keqaqTMP_local(nspec))
 ALLOCATE(gammaTMP(ncomp+nspec))
 ALLOCATE(sTotTMP(ncomp))
-ALLOCATE(NumericalJac(ncomp,ncomp))
+ALLOCATE(NumericalJac_local(ncomp,ncomp))
 
 fjac = 0.0d0
 
@@ -135,25 +135,25 @@ DO jz = 1,nz
               gammaTMP(ik)  = gam(ik,jx,jy,jz)
       end do
       do ksp = 1,nspec
-        keqaqTMP(ksp)  = keqaq(ksp,jx,jy,jz)
+        keqaqTMP_local(ksp)  = keqaq(ksp,jx,jy,jz)
       end do
 
       
       
-      NumericalJac = 0.0d0
+      NumericalJac_local = 0.0d0
       do ik = 1,ncomp
 
          spppTMP(ik) = spppTMP(ik) + perturb
          spppTMP10(ik) = DEXP(spppTMP(ik))
         
-!!!        call GammaResidual(ncomp,nspec,tempc,spppTMP,keqaqTMP,gammaTMP,sTotTMP)
+!!!        call GammaResidual(ncomp,nspec,tempc,spppTMP,keqaqTMP_local,gammaTMP,sTotTMP)
         
         DO ksp = 1,nspec   
           sum = 0.0D0
           DO i = 1,ncomp
             sum = sum + muaq(ksp,i)*(spppTMP(i) + gammaTMP(i))
           END DO
-          spppTMP(ksp+ncomp) = keqaqTMP(ksp) - gammaTMP(ksp+ncomp) + sum
+          spppTMP(ksp+ncomp) = keqaqTMP_local(ksp) - gammaTMP(ksp+ncomp) + sum
           spppTMP10(ksp+ncomp) = DEXP(spppTMP(ksp+ncomp))           
         END DO
       
@@ -168,14 +168,14 @@ DO jz = 1,nz
         END DO
        
         do i = 1,ncomp
-          NumericalJac(ik,i) = ( sTotTMP(i) - s(i,jx,jy,jz) )/perturb
+          NumericalJac_local(ik,i) = ( sTotTMP(i) - s(i,jx,jy,jz) )/perturb
         end do
         
          spppTMP(ik) = spppTMP(ik) - perturb
          spppTMP10(ik) = DEXP(spppTMP(ik))
          
          do i = 1,ncomp
-           fjac(ik,i,jx,jy,jz) = NumericalJac(ik,i)
+           fjac(ik,i,jx,jy,jz) = NumericalJac_local(ik,i)
           end do
         
       END DO

--- a/Source/keqcalc2_init.F90
+++ b/Source/keqcalc2_init.F90
@@ -1,17 +1,17 @@
 !!! *** Copyright Notice ***
-!!! ìCrunchFlowî, Copyright (c) 2016, The Regents of the University of California, through Lawrence Berkeley National Laboratory 
-!!! (subject to receipt of any required approvals from the U.S. Dept. of Energy).† All rights reserved.
-!!!†
+!!! ‚ÄúCrunchFlow‚Äù, Copyright (c) 2016, The Regents of the University of California, through Lawrence Berkeley National Laboratory 
+!!! (subject to receipt of any required approvals from the U.S. Dept. of Energy).¬† All rights reserved.
+!!!¬†
 !!! If you have questions about your rights to use or distribute this software, please contact 
-!!! Berkeley Lab's Innovation & Partnerships Office at††IPO@lbl.gov.
-!!!†
-!!! NOTICE.† This Software was developed under funding from the U.S. Department of Energy and the U.S. Government 
+!!! Berkeley Lab's Innovation & Partnerships Office at¬†¬†IPO@lbl.gov.
+!!!¬†
+!!! NOTICE.¬† This Software was developed under funding from the U.S. Department of Energy and the U.S. Government 
 !!! consequently retains certain rights. As such, the U.S. Government has been granted for itself and others acting 
 !!! on its behalf a paid-up, nonexclusive, irrevocable, worldwide license in the Software to reproduce, distribute copies to the public, 
 !!! prepare derivative works, and perform publicly and display publicly, and to permit other to do so.
 !!!
 !!! *** License Agreement ***
-!!! ìCrunchFlowî, Copyright (c) 2016, The Regents of the University of California, through Lawrence Berkeley National Laboratory)
+!!! ‚ÄúCrunchFlow‚Äù, Copyright (c) 2016, The Regents of the University of California, through Lawrence Berkeley National Laboratory)
 !!! subject to receipt of any required approvals from the U.S. Dept. of Energy).  All rights reserved."
 !!! 
 !!! Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
@@ -125,7 +125,7 @@ REAL(DP)                                              :: sion_tmp
 REAL(DP)                                              :: P_appelo
 REAL(DP)                                              :: P_bars
 REAL(DP)                                              :: Av
-REAL(DP)                                              :: eps_r
+REAL(DP)                                              :: eps_r_local
 REAL(DP)                                              :: RgasAppelo
 REAL(DP)                                              :: ConvertBarsToAtm
 REAL(DP)                                              :: ConvertPaToBars
@@ -387,7 +387,7 @@ IF (SaltCreep) THEN
   D1000_bradleyPitz = U1 *EXP(U2*temp + U3*temp*temp)
   B_BradleyPitz = U7 + U8/temp + U9*temp
     
-  eps_r = D1000_bradleyPitz + C_BradleyPitz * Log( (B_BradleyPitz + P_bars)/(B_BradleyPitz+1000.0) )  
+  eps_r_local = D1000_bradleyPitz + C_BradleyPitz * Log( (B_BradleyPitz + P_bars)/(B_BradleyPitz+1000.0) )  
 
   partialLogEps = C_BradleyPitz/       &
       (  (B_BradleyPitz + P_bars) * ( C_BradleyPitz * Log( (B_BradleyPitz + P_bars)/(B_BradleyPitz+1000.0) ) +   &
@@ -500,7 +500,7 @@ IF (CalciteCreep) THEN
   D1000_bradleyPitz = U1 *EXP(U2*temp + U3*temp*temp)
   B_BradleyPitz = U7 + U8/temp + U9*temp
     
-  eps_r = D1000_bradleyPitz + C_BradleyPitz * Log( (B_BradleyPitz + P_bars)/(B_BradleyPitz+1000.0) )  
+  eps_r_local = D1000_bradleyPitz + C_BradleyPitz * Log( (B_BradleyPitz + P_bars)/(B_BradleyPitz+1000.0) )  
 
   partialLogEps = C_BradleyPitz/       &
       (  (B_BradleyPitz + P_bars) * ( C_BradleyPitz * Log( (B_BradleyPitz + P_bars)/(B_BradleyPitz+1000.0) ) +   &

--- a/Source/read_AqueousFluxSeries.F90
+++ b/Source/read_AqueousFluxSeries.F90
@@ -1,17 +1,17 @@
 !!! *** Copyright Notice ***
-!!! ìCrunchFlowî, Copyright (c) 2016, The Regents of the University of California, through Lawrence Berkeley National Laboratory 
-!!! (subject to receipt of any required approvals from the U.S. Dept. of Energy).† All rights reserved.
-!!!†
+!!! ‚ÄúCrunchFlow‚Äù, Copyright (c) 2016, The Regents of the University of California, through Lawrence Berkeley National Laboratory 
+!!! (subject to receipt of any required approvals from the U.S. Dept. of Energy).¬† All rights reserved.
+!!!¬†
 !!! If you have questions about your rights to use or distribute this software, please contact 
-!!! Berkeley Lab's Innovation & Partnerships Office at††IPO@lbl.gov.
-!!!†
-!!! NOTICE.† This Software was developed under funding from the U.S. Department of Energy and the U.S. Government 
+!!! Berkeley Lab's Innovation & Partnerships Office at¬†¬†IPO@lbl.gov.
+!!!¬†
+!!! NOTICE.¬† This Software was developed under funding from the U.S. Department of Energy and the U.S. Government 
 !!! consequently retains certain rights. As such, the U.S. Government has been granted for itself and others acting 
 !!! on its behalf a paid-up, nonexclusive, irrevocable, worldwide license in the Software to reproduce, distribute copies to the public, 
 !!! prepare derivative works, and perform publicly and display publicly, and to permit other to do so.
 !!!
 !!! *** License Agreement ***
-!!! ìCrunchFlowî, Copyright (c) 2016, The Regents of the University of California, through Lawrence Berkeley National Laboratory)
+!!! ‚ÄúCrunchFlow‚Äù, Copyright (c) 2016, The Regents of the University of California, through Lawrence Berkeley National Laboratory)
 !!! subject to receipt of any required approvals from the U.S. Dept. of Energy).  All rights reserved."
 !!! 
 !!! Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
@@ -54,7 +54,7 @@ USE runtime
 IMPLICIT NONE
 
 INTERFACE
-  SUBROUTINE read_multstring(nout,lchar,parchar,parfind, stringarray,lenarray,section)
+  SUBROUTINE read_multstring(nout,lchar,parchar,parfind, strarray,lenarray,section)
   USE crunchtype
   USE params
   USE strings
@@ -63,7 +63,7 @@ INTERFACE
   INTEGER(I4B), INTENT(OUT)                                   :: lchar
   CHARACTER (LEN=mls), INTENT(IN)                             :: parchar
   CHARACTER (LEN=mls), INTENT(IN OUT)                         :: parfind
-  CHARACTER (LEN=mls), DIMENSION(:), INTENT(IN OUT)           :: stringarray
+  CHARACTER (LEN=mls), DIMENSION(:), INTENT(IN OUT)           :: strarray
   INTEGER(I4B), INTENT(OUT)                                   :: lenarray
   CHARACTER (LEN=mls), INTENT(IN)                             :: section
   END SUBROUTINE read_multstring

--- a/Source/read_FluxWeightedConcentration.F90
+++ b/Source/read_FluxWeightedConcentration.F90
@@ -1,17 +1,17 @@
 !!! *** Copyright Notice ***
-!!! ìCrunchFlowî, Copyright (c) 2016, The Regents of the University of California, through Lawrence Berkeley National Laboratory 
-!!! (subject to receipt of any required approvals from the U.S. Dept. of Energy).† All rights reserved.
-!!!†
+!!! ‚ÄúCrunchFlow‚Äù, Copyright (c) 2016, The Regents of the University of California, through Lawrence Berkeley National Laboratory 
+!!! (subject to receipt of any required approvals from the U.S. Dept. of Energy).¬† All rights reserved.
+!!!¬†
 !!! If you have questions about your rights to use or distribute this software, please contact 
-!!! Berkeley Lab's Innovation & Partnerships Office at††IPO@lbl.gov.
-!!!†
-!!! NOTICE.† This Software was developed under funding from the U.S. Department of Energy and the U.S. Government 
+!!! Berkeley Lab's Innovation & Partnerships Office at¬†¬†IPO@lbl.gov.
+!!!¬†
+!!! NOTICE.¬† This Software was developed under funding from the U.S. Department of Energy and the U.S. Government 
 !!! consequently retains certain rights. As such, the U.S. Government has been granted for itself and others acting 
 !!! on its behalf a paid-up, nonexclusive, irrevocable, worldwide license in the Software to reproduce, distribute copies to the public, 
 !!! prepare derivative works, and perform publicly and display publicly, and to permit other to do so.
 !!!
 !!! *** License Agreement ***
-!!! ìCrunchFlowî, Copyright (c) 2016, The Regents of the University of California, through Lawrence Berkeley National Laboratory)
+!!! ‚ÄúCrunchFlow‚Äù, Copyright (c) 2016, The Regents of the University of California, through Lawrence Berkeley National Laboratory)
 !!! subject to receipt of any required approvals from the U.S. Dept. of Energy).  All rights reserved."
 !!! 
 !!! Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
@@ -54,7 +54,7 @@ USE runtime
 IMPLICIT NONE
 
 INTERFACE
-  SUBROUTINE read_multstring(nout,lchar,parchar,parfind, stringarray,lenarray,section)
+  SUBROUTINE read_multstring(nout,lchar,parchar,parfind, strarray,lenarray,section)
   USE crunchtype
   USE params
   USE strings
@@ -63,7 +63,7 @@ INTERFACE
   INTEGER(I4B), INTENT(OUT)                                   :: lchar
   CHARACTER (LEN=mls), INTENT(IN)                             :: parchar
   CHARACTER (LEN=mls), INTENT(IN OUT)                         :: parfind
-  CHARACTER (LEN=mls), DIMENSION(:), INTENT(IN OUT)           :: stringarray
+  CHARACTER (LEN=mls), DIMENSION(:), INTENT(IN OUT)           :: strarray
   INTEGER(I4B), INTENT(OUT)                                   :: lenarray
   CHARACTER (LEN=mls), INTENT(IN)                             :: section
   END SUBROUTINE read_multstring


### PR DESCRIPTION
## Summary
- Rename interface dummy argument to `strarray` in multiple readers to avoid clashing with concentration module variable
- Use distinct locals `keqaqTMP_local` and `NumericalJac_local` in Jacobian routine
- Rename `eps_r` to `eps_r_local` in equilibrium initialization to prevent module collision

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b666b8e4b083279edc683970653de0