### PR TITLE
Fix inequality operator in speciation routine

### DIFF
--- a/Source/speciation.F90
+++ b/Source/speciation.F90
@@ -471,7 +471,7 @@ DO jz = 1,nz
           ELSE
             npt = nptlink(ns-nsurf)
           END IF
-          IF (npt != 0) THEN
+          IF (npt /= 0) THEN
             psi0_local = psi(1,npt,jx,jy,jz)
             psib_local = psi(2,npt,jx,jy,jz)
             psid_local = psi(3,npt,jx,jy,jz)


### PR DESCRIPTION
## Summary
- fix Fortran inequality operator in `speciation.F90`

## Testing
- `make speciation.o` *(fails: No rule to make target '/lib/petsc/conf/rules')*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b66b1d8df88327a21d4d3421341794